### PR TITLE
Fix: `__read_bib` handling of Scopus Bib Source title

### DIFF
--- a/pybibx/base/pbx.py
+++ b/pybibx/base/pbx.py
@@ -1461,6 +1461,8 @@ class pbx_probe():
         data['abstract'] = data['abstract'].str.replace('[No abstract available]', 'UNKNOWN', regex = False)
         data             = data.reindex(sorted(data.columns), axis = 1)
         if (db == 'scopus'):
+            if ('source title' not in data.columns and 'journal' in data.columns):
+                data['source title'] = data['journal']
             data["abbrev_source_title"] = np.where( (data["abbrev_source_title"] == "UNKNOWN") & (data["source title"] != "UNKNOWN"), data["source title"], data["abbrev_source_title"] )
         return data, entries
     


### PR DESCRIPTION
**`Scopus` CSV export uses `Source title` while Bib export uses `Journal`**

Added fallback: map `journal` to `source title` when missing

Prevents KeyError during Scopus import

<details open><summary>Error Log</summary>

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3812, in get_loc
    return self._engine.get_loc(casted_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pandas/_libs/index.pyx", line 167, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 196, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7088, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7096, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'source title'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kkimj/research/researches/business_model_innovation_to_evaluation/resorces/test4.py", line 14, in <module>
    bibfile   = pbx_probe(file_bib = file_name, db = database, del_duplicated = True)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pybibx/base/pbx.py", line 519, in __init__
    self.data, self.entries = self.__read_bib(file_bib, db, del_duplicated)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pybibx/base/pbx.py", line 1464, in __read_bib
    data["abbrev_source_title"] = np.where( (data["abbrev_source_title"] == "UNKNOWN") & (data["source title"] != "UNKNOWN"), data["source title"], data["abbrev_source_title"] )
                                                                                          ~~~~^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pandas/core/frame.py", line 4107, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3819, in get_loc
```

</details>

